### PR TITLE
add remove_all_jobs function to scheduler.py

### DIFF
--- a/flask_apscheduler/scheduler.py
+++ b/flask_apscheduler/scheduler.py
@@ -117,6 +117,15 @@ class APScheduler(object):
 
         self.__scheduler.remove_job(id, jobstore)
 
+    def delete_all_jobs(self, jobstore=None):
+        """
+        Removes all jobs from the specified job store, or all job stores if none is given.
+        
+        :param str|unicode jobstore: alias of the job store
+        """
+
+        self.__scheduler.remove_all_jobs(jobstore)
+
     def get_job(self, id, jobstore=None):
         """
         Returns the Job that matches the given ``id``.


### PR DESCRIPTION
I need this function to be accessible in order to flush old jobs before creating a new one (to avoid conflicts). Like the other functions in `scheduler.py` the new function just aliases a function from the actual APScheduler class.