### PR TITLE
Implement singleton pattern for APScheduler() class

### DIFF
--- a/flask_apscheduler/scheduler.py
+++ b/flask_apscheduler/scheduler.py
@@ -19,12 +19,12 @@ import socket
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from . import views
-from .utils import fix_job_def, pop_trigger
+from .utils import fix_job_def, pop_trigger, Singleton
 
 LOGGER = logging.getLogger('flask_apscheduler')
 
 
-class APScheduler(object):
+class APScheduler(Singleton):
     """Provides a scheduler integrated to Flask."""
 
     def __init__(self, scheduler=None, app=None):
@@ -60,8 +60,12 @@ class APScheduler(object):
 
     def init_app(self, app):
         """Initializes the APScheduler with a Flask application instance."""
+        ###############################
+        ### Follow a singletone pattern
+        ###############################
 
         self.app = app
+        
         self.app.apscheduler = self
 
         self.__load_config()

--- a/flask_apscheduler/utils.py
+++ b/flask_apscheduler/utils.py
@@ -135,3 +135,11 @@ def extract_timedelta(delta):
     mm, ss = divmod(delta.seconds, 60)
     hh, mm = divmod(mm, 60)
     return w, d, hh, mm, ss
+
+
+class Singleton(object):
+    _instance = None
+    def __new__(cls, *args, **kwargs):
+        if not cls._instance:
+            cls._instance = super(Singleton, cls).__new__(cls, *args, **kwargs)
+        return cls._instance


### PR DESCRIPTION
Currently, when Flask-APScheduler is used in a WSGI
app, for instance, powered by Gunicorn, the APScheduler
class is instantiated for each worker process spawned by
the WSGI web-server (i.e. if I set the '--workers 4' flag
in gunicorn, APScheduler will get instantiated for each worker).

This is also an issue when we set DEBUG=True in the flask
app's config, as this will spawn a Master and a Child process.

The reason this is a problem is that all "n" instantiations of
APScheduler will collectively execute the job "n-times", in
essence doubling, tripling, quadrupling, etc. the execution of
each job.

If I start Gunicorn with 4 workers, and have a job that
dumps a MySQL database ever hour, this job will execute
4 times every hour, at the same time. This is obviously not
what we want. (Not to mention we have more memory overhead
if we have "n" instances of the APScheduler class)

I have provided a Singleton implementation of APScheduler,
which works as follows: If we try and create a new APScheduler
on a worker process, if a pre-existing APScheduler instance exists,
return it! This way, every worker process shares the Singleton
APScheduler object, and each job is executed only once, properly.