### PR TITLE
Fix Typo of `JobLookupError`

### DIFF
--- a/flask_apscheduler/api.py
+++ b/flask_apscheduler/api.py
@@ -130,7 +130,7 @@ def run_job(job_id):
         current_app.apscheduler.run_job(job_id)
         job = current_app.apscheduler.get_job(job_id)
         return jsonify(job)
-    except LookupError:
+    except JobLookupError:
         return jsonify(dict(error_message='Job %s not found' % job_id), status=404)
     except Exception as e:
         return jsonify(dict(error_message=str(e)), status=500)

--- a/flask_apscheduler/scheduler.py
+++ b/flask_apscheduler/scheduler.py
@@ -21,6 +21,7 @@ import warnings
 
 from apscheduler.events import EVENT_ALL
 from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.jobstores.base import JobLookupError
 from flask import make_response
 from . import api
 from .utils import fix_job_def, pop_trigger
@@ -265,7 +266,7 @@ class APScheduler(object):
         job = self._scheduler.get_job(id, jobstore)
 
         if not job:
-            raise LookupError(id)
+            raise JobLookupError(id)
 
         job.func(*job.args, **job.kwargs)
 


### PR DESCRIPTION
The [LookupError](https://docs.python.org/2/library/exceptions.html#exceptions.LookupError) is python base exception for errors like `IndexError`, `KeyError`, etc. It will generate a message like `Job xxx not found` if the job func throw an `IndexError` or `KeyError`.

The fix is simply to replace `LookupError` to `apscheduler.jobstores.base.JobLookupError`.