### PR TITLE
new property task for scheduled_job decorator

### DIFF
--- a/examples/decorated.py
+++ b/examples/decorated.py
@@ -22,7 +22,7 @@ def job2():
 
 
 @scheduler.task("cron", id="do_job_3", week="*", day_of_week="sun")
-def task_purge_processed():
+def job3():
     print("Job 3 executed")
 
 

--- a/examples/decorated.py
+++ b/examples/decorated.py
@@ -1,0 +1,38 @@
+from flask import Flask
+from flask_apscheduler import APScheduler
+
+
+class Config(object):
+    SCHEDULER_API_ENABLED = True
+
+
+scheduler = APScheduler()
+
+
+# interval examples
+@scheduler.task("interval", id="do_job_1", seconds=30, misfire_grace_time=900)
+def job1():
+    print("Job 1 executed")
+
+
+# cron examples
+@scheduler.task("cron", id="do_job_2", minute="*")
+def job2():
+    print("Job 2 executed")
+
+
+@scheduler.task("cron", id="do_job_3", week="*", day_of_week="sun")
+def task_purge_processed():
+    print("Job 3 executed")
+
+
+if __name__ == '__main__':
+    app = Flask(__name__)
+    app.config.from_object(Config())
+
+    # it is also possible to enable the API directly
+    # scheduler.api_enabled = True
+    scheduler.init_app(app)
+    scheduler.start()
+
+    app.run()

--- a/flask_apscheduler/scheduler.py
+++ b/flask_apscheduler/scheduler.py
@@ -66,7 +66,7 @@ class APScheduler(object):
     def scheduler(self):
         """Get the base scheduler."""
         return self._scheduler
-    
+
     @property
     def task(self):
         """Get the base scheduler decorator"""

--- a/flask_apscheduler/scheduler.py
+++ b/flask_apscheduler/scheduler.py
@@ -66,6 +66,11 @@ class APScheduler(object):
     def scheduler(self):
         """Get the base scheduler."""
         return self._scheduler
+    
+    @property
+    def task(self):
+        """Get the base scheduler decorator"""
+        return self._scheduler.scheduled_job
 
     def init_app(self, app):
         """Initialize the APScheduler with a Flask application instance."""


### PR DESCRIPTION
Adding this simple property we can easily access APScheduler's scheduled_job decorator in a nice way.
So in Flask we could create a scheduler.py file and write our schedule's as below, flask_apscheduler automaticly detecs them :

```
@scheduler.task("cron", id="test_print_hello", minute="*")
def print_hello():
    print("Hello as Cron")
```

or 

```
@scheduler.task("interval", id="test_print_hello", seconds=120, misfire_grace_time=900)
def print_hello():
    print("Hello as Interval")
```

See: https://apscheduler.readthedocs.io/en/latest/modules/triggers/cron.html