### PR TITLE
Do not start APScheduler when the current process is werkzeug reloader

### DIFF
--- a/flask_apscheduler/scheduler.py
+++ b/flask_apscheduler/scheduler.py
@@ -24,7 +24,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.jobstores.base import JobLookupError
 from flask import make_response
 from . import api
-from .utils import fix_job_def, pop_trigger
+from .utils import fix_job_def, is_werkzeug_reloader_process, pop_trigger
 
 LOGGER = logging.getLogger('flask_apscheduler')
 
@@ -89,6 +89,11 @@ class APScheduler(object):
         Start the scheduler.
         :param bool paused: if True, don't start job processing until resume is called.
         """
+        # Flask in debug mode spawns a child process so that it can restart that process each time your code changes,
+        # the new child process initializes and starts a new APScheduler causing the jobs to run twice.
+        if is_werkzeug_reloader_process():
+            return
+
         if self.host_name not in self.allowed_hosts and '*' not in self.allowed_hosts:
             LOGGER.debug('Host name %s is not allowed to start the APScheduler. Servers allowed: %s' %
                          (self.host_name, ','.join(self.allowed_hosts)))

--- a/flask_apscheduler/utils.py
+++ b/flask_apscheduler/utils.py
@@ -15,6 +15,7 @@
 """Utility module."""
 
 import dateutil.parser
+import os
 import six
 
 from apscheduler.triggers.cron import CronTrigger
@@ -147,3 +148,7 @@ def extract_timedelta(delta):
     mm, ss = divmod(delta.seconds, 60)
     hh, mm = divmod(mm, 60)
     return w, d, hh, mm, ss
+
+
+def is_werkzeug_reloader_process():
+    return os.environ.get('WERKZEUG_RUN_MAIN') == 'true'


### PR DESCRIPTION
* Flask in debug mode spawns a child process so that it can restart that process each time your code changes, the new child process initializes and starts a new APScheduler causing the jobs to run twice.
* Fixes https://github.com/viniciuschiele/flask-apscheduler/issues/139
