### PR TITLE
fixed pip install error trying to install LICENSE to /usr #120

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ setup(
     long_description_content_type='text/x-rst',
     keywords=['apscheduler', 'scheduler', 'scheduling', 'cron'],
     install_requires=['flask>=0.10.1', 'apscheduler>=3.2.0,<4.0.0', 'python-dateutil>=2.4.2'],
-    data_files=[('', ['LICENSE'])],
+    package_data={'Flask-APScheduler': ['LICENSE']},
+    include_package_data=True,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
This fixes issue  #120 . Switched use of "data_files" to "package_data" in setup.py. I confirmed that this installs properly now using "pip3 install ." (while in the root dir) and I confirmed that the LICENSE file is now deployed on my system to:
/usr/local/lib/python3.8/dist-packages/Flask_APScheduler-1.12.2.dist-info/LICENSE