### PR TITLE
Add logging to API functions

### DIFF
--- a/flask_apscheduler/api.py
+++ b/flask_apscheduler/api.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 from apscheduler.jobstores.base import ConflictingIdError, JobLookupError
 from collections import OrderedDict
 from flask import current_app, request, Response
@@ -41,8 +43,10 @@ def add_job():
         job = current_app.apscheduler.add_job(**data)
         return jsonify(job)
     except ConflictingIdError:
+        logging.warning(f'Job {data.get("id")} already exists.')
         return jsonify(dict(error_message='Job %s already exists.' % data.get('id')), status=409)
     except Exception as e:
+        logging.error(e, exc_info=True)
         return jsonify(dict(error_message=str(e)), status=500)
 
 
@@ -53,8 +57,10 @@ def delete_job(job_id):
         current_app.apscheduler.remove_job(job_id)
         return Response(status=204)
     except JobLookupError:
+        logging.warning(f'Job {job_id} not found.')
         return jsonify(dict(error_message='Job %s not found' % job_id), status=404)
     except Exception as e:
+        logging.error(e, exc_info=True)
         return jsonify(dict(error_message=str(e)), status=500)
 
 
@@ -64,6 +70,7 @@ def get_job(job_id):
     job = current_app.apscheduler.get_job(job_id)
 
     if not job:
+        logging.warning(f'Job {job_id} not found.')
         return jsonify(dict(error_message='Job %s not found' % job_id), status=404)
 
     return jsonify(job)
@@ -92,8 +99,10 @@ def update_job(job_id):
         job = current_app.apscheduler.get_job(job_id)
         return jsonify(job)
     except JobLookupError:
+        logging.warning(f'Job {job_id} not found.')
         return jsonify(dict(error_message='Job %s not found' % job_id), status=404)
     except Exception as e:
+        logging.error(e, exc_info=True)
         return jsonify(dict(error_message=str(e)), status=500)
 
 
@@ -105,8 +114,10 @@ def pause_job(job_id):
         job = current_app.apscheduler.get_job(job_id)
         return jsonify(job)
     except JobLookupError:
+        logging.warning(f'Job {job_id} not found.')
         return jsonify(dict(error_message='Job %s not found' % job_id), status=404)
     except Exception as e:
+        logging.error(e, exc_info=True)
         return jsonify(dict(error_message=str(e)), status=500)
 
 
@@ -118,8 +129,10 @@ def resume_job(job_id):
         job = current_app.apscheduler.get_job(job_id)
         return jsonify(job)
     except JobLookupError:
+        logging.warning(f'Job {job_id} not found.')
         return jsonify(dict(error_message='Job %s not found' % job_id), status=404)
     except Exception as e:
+        logging.error(e, exc_info=True)
         return jsonify(dict(error_message=str(e)), status=500)
 
 
@@ -131,6 +144,8 @@ def run_job(job_id):
         job = current_app.apscheduler.get_job(job_id)
         return jsonify(job)
     except JobLookupError:
+        logging.warning(f'Job {job_id} not found.')
         return jsonify(dict(error_message='Job %s not found' % job_id), status=404)
     except Exception as e:
+        logging.error(e, exc_info=True)
         return jsonify(dict(error_message=str(e)), status=500)


### PR DESCRIPTION
Before this patch, we lost the error log and associated stack trace from APScheduler. This patch logs these events along with the existing JSON response that the API already provides.

With all 4XX errors, I decided to treat them as a warning to match the HTTP spec.