### PR TITLE
Update import statement to specify function name

### DIFF
--- a/flask_apscheduler/scheduler.py
+++ b/flask_apscheduler/scheduler.py
@@ -14,7 +14,6 @@
 
 """APScheduler implementation."""
 
-import flask
 import functools
 import logging
 import socket
@@ -25,6 +24,7 @@ from apscheduler.events import EVENT_ALL
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.jobstores.base import JobLookupError
 from flask import make_response
+from flask.helpers import get_debug_flag
 from . import api
 from .utils import fix_job_def, pop_trigger
 
@@ -94,7 +94,7 @@ class APScheduler(object):
 
         # Flask in debug mode spawns a child process so that it can restart the process each time your code changes,
         # the new child process initializes and starts a new APScheduler causing the jobs to run twice.
-        if flask.helpers.get_debug_flag() and not werkzeug.serving.is_running_from_reloader():
+        if get_debug_flag() and not werkzeug.serving.is_running_from_reloader():
             return
 
         if self.host_name not in self.allowed_hosts and '*' not in self.allowed_hosts:


### PR DESCRIPTION
This import statement update allows Quart to work around a limitation of the quart.flask_patch() methods ability to wrap the flask functionality. The original implementation of the import statement in the scheduler.py file in flask_apscheduler leaves quart users with an import error since the originating call can be wrapped by flask_patch functionality but the import call from the apscheduler extension to flask cannot be caught and wrapped.

[Quart](https://github.com/pallets/quart) is an asyncio reimplementation of the popular [Flask](http://flask.pocoo.org/) microframework API

Like Flask, Quart has an ecosystem of extensions for more specific needs. In addition a number of the Flask extensions work with Quart. It should be possible to migrate to Quart from Flask by a find and replace of flask to quart and then adding async and await keywords. 

[Documentation of the Quart methodology for wrapping flask extensions/function](https://quart.palletsprojects.com/en/latest/how_to_guides/flask_extensions.html#flask-extensions)