### PR TITLE
Compatibility with flask 2.3.0

### DIFF
--- a/flask_apscheduler/json.py
+++ b/flask_apscheduler/json.py
@@ -6,29 +6,17 @@ import flask
 from apscheduler.job import Job
 from .utils import job_to_dict
 
-import json  # noqa
-
-
-loads = json.loads
-
-
-def dumps(obj, indent=None):
-    return json.dumps(obj, indent=indent, cls=JSONEncoder)
-
 
 def jsonify(data, status=None):
-    indent = None
-    if flask.current_app.config['JSONIFY_PRETTYPRINT_REGULAR']:
-        indent = 2
-    return flask.current_app.response_class(dumps(data, indent=indent), status=status, mimetype='application/json')
+    content = flask.current_app.json.dumps(data, default=_default)
+    return flask.current_app.response_class(content, status=status, mimetype='application/json')
 
 
-class JSONEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, datetime.datetime):
-            return obj.isoformat()
+def _default(obj):
+    if isinstance(obj, datetime.datetime):
+        return obj.isoformat()
 
-        if isinstance(obj, Job):
-            return job_to_dict(obj)
+    if isinstance(obj, Job):
+        return job_to_dict(obj)
 
-        return super(JSONEncoder, self).default(obj)
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-flask>=0.10.1
+flask>=2.2.0,<3.0.0
 apscheduler>=3.2.0,<4.0.0
 python-dateutil>=2.4.2

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/x-rst',
     keywords=['apscheduler', 'scheduler', 'scheduling', 'cron'],
-    install_requires=['flask>=0.10.1', 'apscheduler>=3.2.0,<4.0.0', 'python-dateutil>=2.4.2'],
+    install_requires=['flask>=2.2.0,<3.0.0', 'apscheduler>=3.2.0,<4.0.0', 'python-dateutil>=2.4.2'],
     package_data={'Flask-APScheduler': ['LICENSE']},
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
* Make `flask-apscheduler` compatible with `flask` `2.3.0`
* Change minimum required `flask` version to `2.2.0`
* Fix #226