### PR TITLE
Change minimum required flask version to 2.2.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-flask>=2.2.0,<3.0.0
+flask>=2.2.5,<3.0.0
 apscheduler>=3.2.0,<4.0.0
 python-dateutil>=2.4.2

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     long_description_content_type="text/x-rst",
     keywords=["apscheduler", "scheduler", "scheduling", "cron"],
     python_requires=">=3.8",
-    install_requires=["flask>=2.2.0,<3.0.0", "apscheduler>=3.2.0,<4.0.0", "python-dateutil>=2.4.2"],
+    install_requires=["flask>=2.2.5,<3.0.0", "apscheduler>=3.2.0,<4.0.0", "python-dateutil>=2.4.2"],
     package_data={"Flask-APScheduler": ["LICENSE"]},
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
* flask versions prior to 2.2.5 have a [security vulnerability](https://devhub.checkmarx.com/cve-details/CVE-2023-30861/?utm_source=jetbrains&utm_medium=referral&utm_campaign=idea)