### PR TITLE
Allow install flask 3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-flask>=2.2.5,<3.0.0
+flask>=2.2.5,<4.0.0
 apscheduler>=3.2.0,<4.0.0
 python-dateutil>=2.4.2

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     long_description_content_type="text/x-rst",
     keywords=["apscheduler", "scheduler", "scheduling", "cron"],
     python_requires=">=3.8",
-    install_requires=["flask>=2.2.5,<3.0.0", "apscheduler>=3.2.0,<4.0.0", "python-dateutil>=2.4.2"],
+    install_requires=["flask>=2.2.5,<4.0.0", "apscheduler>=3.2.0,<4.0.0", "python-dateutil>=2.4.2"],
     package_data={"Flask-APScheduler": ["LICENSE"]},
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
I tested the apscheduler with flask version 3.0.0 all tests pass also my app is working with this. I think is should be safe allow install it also with flask 3.0.0